### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": "^7.2",
 
-        "sylius/sylius": "~1.3.0@dev"
+        "sylius/sylius": "~1.3.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",


### PR DESCRIPTION
 $ composer require setono/sylius-analytics-plugin
Using version ^1.3@dev for setono/sylius-analytics-plugin
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for setono/sylius-analytics-plugin ^1.3@dev -> satisfiable by setono/sylius-analytics-plugin[1.3.x-dev].
    - setono/sylius-analytics-plugin 1.3.x-dev requires sylius/sylius ~1.3.0@dev -> satisfiable by sylius/sylius[1.3.x-dev, v1.3.0, v1.3.0-BETA, v1.3.1, v1.3.2, v1.3.3, v1.3.4, v1.3.5, v1.3.6, v1.3.7, v1.3.8, v1.3.9] but these conflict with your requirements or minimum-stability.