### PR TITLE
PHP 8 support for the 2.x version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,6 +22,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "highest"
@@ -66,6 +67,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "highest"
@@ -102,6 +104,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "highest"
@@ -137,6 +140,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "lowest"
@@ -170,6 +174,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "highest"
@@ -217,6 +222,7 @@ jobs:
             matrix:
                 php-version:
                     - "7.4"
+                    - "8.0"
 
                 dependencies:
                     - "highest"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.4",
+        "php": ">=7.4",
         "ext-json": "*",
         "doctrine/collections": "^1.6",
         "knplabs/knp-menu": "^3.1",


### PR DESCRIPTION
Version 3.0 isn't released yet, but I need PHP 8 support.
This should add support for PHP 8 for the 2.x versions and run the workflow on both PHP 7.4 and PHP 8.