### PR TITLE
Support Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
-        "symfony/event-dispatcher-contracts": "^1.1",
+        "symfony/event-dispatcher-contracts": "^1.1 || ^2.3",
         "symfony/form": "^4.4 || ^5.0",
         "symfony/http-foundation": "^4.4 || ^5.0.7",
         "symfony/http-kernel": "^4.4 || ^5.0",


### PR DESCRIPTION
In order to upgrade to Symfony 5.3 a major version bump is needed for the event dispatcher contracts. Not too much has changed except the type hints of the parameters of a method were added, assuming the right types were already passed anyway, this should not cause any issues.